### PR TITLE
skip sign for estimateGas and not to restore sender address from sign…

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -190,12 +190,7 @@ func (c *CallFrame) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (cl *ETHClient) EstimateGasFromTx(ctx context.Context, tx *gethtypes.Transaction) (uint64, error) {
-	from, err := gethtypes.LatestSignerForChainID(tx.ChainId()).Sender(tx)
-	if err != nil {
-		return 0, err
-	}
-
+func (cl *ETHClient) EstimateGasFromTx(ctx context.Context, tx *gethtypes.Transaction, from common.Address) (uint64, error) {
 	callMsg := ethereum.CallMsg{
 		From:  from,
 		To:    tx.To(),

--- a/pkg/relay/ethereum/signer.go
+++ b/pkg/relay/ethereum/signer.go
@@ -16,6 +16,7 @@ type EthereumSigner struct {
 	gethSigner gethtypes.Signer
 	addressCache common.Address
 	logger *log.RelayLogger
+	NoSign bool
 }
 
 func NewEthereumSigner(bytesSigner signer.Signer, chainID *big.Int) (*EthereumSigner, error) {
@@ -38,6 +39,7 @@ func NewEthereumSigner(bytesSigner signer.Signer, chainID *big.Int) (*EthereumSi
 		gethSigner: gethSigner,
 		addressCache: addr,
 		logger: nil,
+		NoSign: false,
 	}, nil
 }
 
@@ -56,6 +58,10 @@ func (s *EthereumSigner) Address() common.Address {
 func (s *EthereumSigner) Sign(address common.Address, tx *gethtypes.Transaction) (*gethtypes.Transaction, error) {
 	if address != s.Address() {
 		return nil, fmt.Errorf("unauthorized address: authorized=%v, given=%v", s.Address(), address)
+	}
+
+	if s.NoSign {
+		return tx, nil
 	}
 
 	txHash := s.gethSigner.Hash(tx)

--- a/pkg/relay/ethereum/tx.go
+++ b/pkg/relay/ethereum/tx.go
@@ -681,7 +681,6 @@ func (iter *CallIter) buildSingleTx(ctx context.Context, c *Chain) (*CallIterBui
 		opts.GasLimit = txGasLimit
 	}
 
-	c.ethereumSigner.NoSign = false
 	tx, err := c.BuildMessageTx(opts, iter.Current(), iter.skipUpdateClientCommitment)
 	if err != nil {
 		logger.Error("failed to build tx", err)
@@ -781,7 +780,6 @@ func (iter *CallIter) buildMultiTx(ctx context.Context, c *Chain) (*CallIterBuil
 	opts.GasLimit = lastOkGasLimit
 
 	// add raw tx to log attribute
-	c.ethereumSigner.NoSign = false
 	tx, err := c.multicall3.Aggregate(opts, lastOkCalls)
 	if err != nil {
 		logger.Error("failed to build multicall tx with real send parameters", err)


### PR DESCRIPTION
 - Add new state NoSign to EthereumSigner.
    If NoSign=true, EthereumSigner's Sign function returns input tx as is (without sign). 
    Note that opts.Signer is mandatory parameter(https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/bind/base.go#L418 )
 - Not to restore address from gethtypes.LatestSignerForChainID. This function expect that tx has valid signature.

