### PR TITLE
Use context appropriately

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -88,7 +88,7 @@ func (cl *ETHClient) WaitForReceiptAndGet(ctx context.Context, txHash common.Has
 			receipt = rc
 			return nil
 		},
-		cl.option.retryOpts...,
+		append(cl.option.retryOpts, retry.Context(ctx))...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/client/proof.go
+++ b/pkg/client/proof.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -21,8 +22,8 @@ type StateProof struct {
 	StorageProofRLP [][]byte
 }
 
-func (cl ETHClient) GetProof(address common.Address, storageKeys [][]byte, blockNumber *big.Int) (*StateProof, error) {
-	bz, err := cl.getProof(address, storageKeys, "0x"+blockNumber.Text(16))
+func (cl ETHClient) GetProof(ctx context.Context, address common.Address, storageKeys [][]byte, blockNumber *big.Int) (*StateProof, error) {
+	bz, err := cl.getProof(ctx, address, storageKeys, "0x"+blockNumber.Text(16))
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +94,7 @@ func (cl ETHClient) GetProof(address common.Address, storageKeys [][]byte, block
 	return &encodedProof, nil
 }
 
-func (cl ETHClient) getProof(address common.Address, storageKeys [][]byte, blockNumber string) ([]byte, error) {
+func (cl ETHClient) getProof(ctx context.Context, address common.Address, storageKeys [][]byte, blockNumber string) ([]byte, error) {
 	hashes := []common.Hash{}
 	for _, k := range storageKeys {
 		var h common.Hash
@@ -103,7 +104,7 @@ func (cl ETHClient) getProof(address common.Address, storageKeys [][]byte, block
 		hashes = append(hashes, h)
 	}
 	var msg json.RawMessage
-	if err := cl.Raw().Call(&msg, "eth_getProof", address, hashes, blockNumber); err != nil {
+	if err := cl.Raw().CallContext(ctx, &msg, "eth_getProof", address, hashes, blockNumber); err != nil {
 		return nil, err
 	}
 	return msg, nil

--- a/pkg/relay/ethereum/chain.go
+++ b/pkg/relay/ethereum/chain.go
@@ -60,7 +60,7 @@ type Chain struct {
 
 var _ core.Chain = (*Chain)(nil)
 
-func NewChain(config ChainConfig) (*Chain, error) {
+func NewChain(ctx context.Context, config ChainConfig) (*Chain, error) {
 	logger := GetModuleLogger()
 
 	id := big.NewInt(int64(config.EthChainId))
@@ -93,7 +93,7 @@ func NewChain(config ChainConfig) (*Chain, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to build signer: %v", err)
 	}
-	ethereumSigner, err := NewEthereumSigner(signer, big.NewInt(int64(config.EthChainId)))
+	ethereumSigner, err := NewEthereumSigner(ctx, signer, big.NewInt(int64(config.EthChainId)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build ethreum signer: %v", err)
 	}

--- a/pkg/relay/ethereum/client.go
+++ b/pkg/relay/ethereum/client.go
@@ -27,8 +27,9 @@ func (chain *Chain) TxOpts(ctx context.Context, useLatestNonce bool) (*bind.Tran
 	addr := chain.ethereumSigner.Address()
 
 	txOpts := &bind.TransactOpts{
-		From:   addr,
-		Signer: chain.ethereumSigner.Sign,
+		From:    addr,
+		Signer:  chain.ethereumSigner.Sign,
+		Context: ctx,
 	}
 
 	if useLatestNonce {

--- a/pkg/relay/ethereum/config.go
+++ b/pkg/relay/ethereum/config.go
@@ -1,6 +1,7 @@
 package ethereum
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -25,7 +26,7 @@ const TxTypeLegacy = "legacy"
 const TxTypeDynamic = "dynamic"
 
 func (c ChainConfig) Build() (core.Chain, error) {
-	return NewChain(c)
+	return NewChain(context.Background(), c)
 }
 
 func (c ChainConfig) Validate() error {

--- a/pkg/relay/ethereum/signer.go
+++ b/pkg/relay/ethereum/signer.go
@@ -13,6 +13,7 @@ import (
 )
 
 type EthereumSigner struct {
+	ctx          context.Context
 	bytesSigner  signer.Signer
 	gethSigner   gethtypes.Signer
 	addressCache common.Address
@@ -36,6 +37,7 @@ func NewEthereumSigner(ctx context.Context, bytesSigner signer.Signer, chainID *
 	gethSigner := gethtypes.LatestSignerForChainID(chainID)
 
 	return &EthereumSigner{
+		ctx:          ctx,
 		bytesSigner:  bytesSigner,
 		gethSigner:   gethSigner,
 		addressCache: addr,
@@ -71,7 +73,7 @@ func (s *EthereumSigner) Sign(address common.Address, tx *gethtypes.Transaction)
 		s.logger.Info("try to sign", "address", address, "txHash", txHash.Hex())
 	}
 
-	sig, err := s.bytesSigner.Sign(context.TODO(), txHash.Bytes())
+	sig, err := s.bytesSigner.Sign(s.ctx, txHash.Bytes())
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign tx: %v", err)
 	}

--- a/pkg/relay/ethereum/signer.go
+++ b/pkg/relay/ethereum/signer.go
@@ -20,8 +20,8 @@ type EthereumSigner struct {
 	NoSign       bool
 }
 
-func NewEthereumSigner(bytesSigner signer.Signer, chainID *big.Int) (*EthereumSigner, error) {
-	pkbytes, err := bytesSigner.GetPublicKey(context.TODO())
+func NewEthereumSigner(ctx context.Context, bytesSigner signer.Signer, chainID *big.Int) (*EthereumSigner, error) {
+	pkbytes, err := bytesSigner.GetPublicKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fail to get public key")
 	}

--- a/pkg/relay/ethereum/tx.go
+++ b/pkg/relay/ethereum/tx.go
@@ -109,7 +109,7 @@ func (c *Chain) SendMsgs(ctx context.Context, msgs []sdk.Msg) ([]core.MsgID, err
 		logger.Info("successfully sent tx")
 		if c.msgEventListener != nil {
 			for i := from; i < iter.Cursor(); i++ {
-				if err := c.msgEventListener.OnSentMsg(context.TODO(), []sdk.Msg{msgs[i]}); err != nil {
+				if err := c.msgEventListener.OnSentMsg(ctx, []sdk.Msg{msgs[i]}); err != nil {
 					logger.Error("failed to OnSendMsg call", err, "index", i)
 				}
 			}


### PR DESCRIPTION
This is the subsequent PR of https://github.com/datachainlab/ethereum-ibc-relay-chain/pull/63 and part of the fourth phase of the OpenTelemetry integration described on https://github.com/hyperledger-labs/yui-relayer/pull/153.
In this PR, I have replaced `context.TODO()` with an appropriate context and added a context argument if necessary.

I have confirmed that the following CIs pass:

* https://github.com/datachainlab/yui-relayer-build/actions/runs/13646997205
* https://github.com/datachainlab/yui-relayer-build/actions/runs/13646997210
* https://github.com/datachainlab/cosmos-ethereum-ibc-lcp/actions/runs/13648015923